### PR TITLE
2.7 fixes. need to understand why?

### DIFF
--- a/ProcessPageListPermissions.module
+++ b/ProcessPageListPermissions.module
@@ -151,6 +151,7 @@ class ProcessPageListPermissions extends Process {
         if ($id && count($data)) {
             $page = wire('pages')->get($id);
             if ($page->id) {
+                $page->setTrackChanges(true); 
                 $page->view_groups = new PageArray();
                 $page->edit_groups = new PageArray();
                 foreach ($data as $group_id => $perms) {
@@ -167,6 +168,10 @@ class ProcessPageListPermissions extends Process {
                 // enable manage_access if groups are/were selected
                 if (count($page->view_groups) || count($page->edit_groups)) $page->manage_access = 1;
                 // save page (triggers rebuilding of permissions)
+                // Had to add these after PW 2.7 update
+                $page->trackChange('view_groups');
+                $page->trackChange('edit_groups');
+                $page->trackChange('manage_access');
                 $page->save();
                 // generate JSON output for JavaScript AJAX POST request
                 $icon = count($page->view_groups) || count($page->edit_groups) ? 'lock' : 'unlock-alt';


### PR DESCRIPTION
We found out that UserGroups (and this module) were not working with PW 2.7. I don't yet fully understand why, but I have fixes for both modules. Though I don't believe that the changes in UserGroups do work in earlier PW versions, so need to go through this with better time and keep the fixes in separate branch until that.

Problem with this module was that the $page->save() didn't save view_groups and edit_groups. So now I am manually letting PW know that those fields have changed (I think it is safe to assume that all of those have changed when we go into this method - ajax save has happened).
